### PR TITLE
Tensorboard fixes

### DIFF
--- a/src/AppToolbar.jsx
+++ b/src/AppToolbar.jsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useRef } from 'react'
+import { useActor } from '@xstate/react'
+import {
+  AppBar, Icon, IconButton, Toolbar, Typography
+} from '@material-ui/core'
+import { toggleIconDataUri } from 'itk-viewer-icons'
+import toggleUICollapsed from './toggleUICollapsed'
+import './Panel.css'
+
+function AppToolbar(props) {
+  const { service } = props
+  const collapseUIButton = useRef(null)
+  const [ state, send ] = useActor(service)
+
+  useEffect(() => {
+    state.context.main.collapseUIButton = collapseUIButton.current
+  }, [])
+
+  const handleToggle = () => {
+    send('TOGGLE_UI_COLLAPSED')
+    toggleUICollapsed(state.context)
+  }
+  
+  return (
+    <AppBar className='appBar'>
+      <Toolbar>
+        <IconButton
+          size='small'
+          ref={ collapseUIButton }
+          color='inherit'
+          onClick={ handleToggle }
+          edge='start'
+        >
+          <Icon>
+            <img src={ toggleIconDataUri } alt='toggle'/>
+          </Icon>
+        </IconButton>
+        <Typography variant='h5' noWrap>
+          ITK Viewer
+        </Typography>
+      </Toolbar>
+    </AppBar>
+  )
+}
+
+export default AppToolbar

--- a/src/CollapseUIButton.jsx
+++ b/src/CollapseUIButton.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef } from 'react'
+import { useActor } from '@xstate/react'
+import { Icon, IconButton } from '@material-ui/core'
+import { toggleIconDataUri } from 'itk-viewer-icons'
+import toggleUICollapsed from './toggleUICollapsed'
+import './Panel.css'
+
+function CollapseUIButton(props) {
+  const { service } = props
+  const collapseUIButton = useRef(null)
+  const [ state, send ] = useActor(service)
+
+  useEffect(() => {
+    state.context.main.collapseUIButton = collapseUIButton.current
+  }, [])
+
+  const handleToggle = () => {
+    send('TOGGLE_UI_COLLAPSED')
+    toggleUICollapsed(state.context)
+  }
+
+  return (
+    <div className='appBar'>
+      <IconButton
+        size='small'
+        ref={ collapseUIButton }
+        color='inherit'
+        onClick={ handleToggle }
+        edge='start'
+      >
+        <Icon>
+          <img src={ toggleIconDataUri } alt='toggle'/>
+        </Icon>
+      </IconButton>
+    </div>
+  )
+}
+
+export default CollapseUIButton

--- a/src/Images/BlendModeSelector.jsx
+++ b/src/Images/BlendModeSelector.jsx
@@ -47,11 +47,11 @@ function BlendModeSelector(props) {
 
   return(
     <div className='blendSelector'>
-      <Tooltip ref={ blendModeDiv } title='Blend mode'>
+      <label ref={ blendModeDiv } data-tooltip-left data-tooltip='Blend mode'>
         <Icon className='blendModeButton'>
           <img src={ blendModeIconDataUri }/>
         </Icon>
-      </Tooltip>
+      </label>
       <Select
         ref={ blendModeSelector }
         className='selector'

--- a/src/Images/ColorRangeInput.jsx
+++ b/src/Images/ColorRangeInput.jsx
@@ -81,7 +81,7 @@ function ColorRangeInput(props) {
         className='uiRow'
         style={{background: 'rgba(127, 127, 127, 0.5)'}}
       >
-        <Tooltip title='Interpolation'>
+        <label data-tooltip-left data-tooltip='Interpolation'>
           <ToggleButton
 						size='small'
             className='interpolationButton toggleButton'
@@ -93,7 +93,7 @@ function ColorRangeInput(props) {
               <img src={ interpolationIconDataUri }/>
             </Icon>
           </ToggleButton>
-        </Tooltip>
+        </label>
         <TextField
           className='numberInput'
           type='number'

--- a/src/Images/GradientOpacitySlider.jsx
+++ b/src/Images/GradientOpacitySlider.jsx
@@ -45,11 +45,11 @@ function GradientOpacitySlider(props) {
 
   return(
     <div className='iconWithSlider'>
-      <Tooltip ref={ sliderEntry } title='Gradient opacity scale'>
+      <label ref={ sliderEntry } data-tooltip-left data-tooltip='Gradient opacity scale'>
         <IconButton size='small' onClick={() => { setVertSlider(!vertSlider) }}>
           <Icon className='sliderEntry'><img src={ gradientIconDataUri }/></Icon>
         </IconButton>
-      </Tooltip>
+      </label>
       <div className='gradientOpacityScale'>
         <Slider
           ref={ gradientOpacitySlider }

--- a/src/Images/SampleDistanceSlider.jsx
+++ b/src/Images/SampleDistanceSlider.jsx
@@ -32,14 +32,14 @@ function SampleDistanceSlider(props) {
 
   return(
     <div className='iconWithSlider'>
-      <Tooltip ref={ spacingDiv } title='Volume sample distance'>
+      <label ref={ spacingDiv } data-tooltip-top-screenshot='Volume sample distance'>
         <Icon
           className='sampleDistanceButton'
           style={{ margin: '0 10px 15px 0' }}
         >
           <img src={ sampleDistanceIconDataUri } />
         </Icon>
-      </Tooltip>
+      </label>
       <Slider
         ref={ spacingElement }
         className='slider'

--- a/src/Images/ShadowToggle.jsx
+++ b/src/Images/ShadowToggle.jsx
@@ -20,7 +20,7 @@ function ShadowToggle(props) {
   }, [])
 
   return(
-    <Tooltip ref={ shadowButton } title='Use Shadow'>
+    <label ref={ shadowButton } data-tooltip-left data-tooltip='Use Shadow'>
       <ToggleButton
 				size='small'
         className='toggleButton'
@@ -36,7 +36,7 @@ function ShadowToggle(props) {
           <img src={ shadowIconDataUri }/>
         </Icon>
       </ToggleButton>
-    </Tooltip>
+    </label>
   )
 }
 

--- a/src/Images/TransferFunctionWidget.jsx
+++ b/src/Images/TransferFunctionWidget.jsx
@@ -3,7 +3,7 @@ import { useActor } from '@xstate/react'
 
 import vtkMouseRangeManipulator from '@kitware/vtk.js/Interaction/Manipulators/MouseRangeManipulator'
 import vtkItkPiecewiseGaussianWidget from '../vtk/ItkPiecewiseGaussianWidget'
-import macro from '@kitware/vtk.js/macro'
+import macro from '@kitware/vtk.js/macros'
 
 import '../style.css'
 

--- a/src/Main/AnnotationsButton.jsx
+++ b/src/Main/AnnotationsButton.jsx
@@ -15,7 +15,7 @@ function AnnotationsButton(props) {
   }, [])
 
   return(
-    <Tooltip ref={ annotationsButton } title='Annotations'>
+    <label ref={ annotationsButton } data-tooltip-left data-tooltip='Annotations'>
       <ToggleButton
         size='small'
         className='toggleButton'
@@ -27,7 +27,7 @@ function AnnotationsButton(props) {
           <img src={ annotationsIconDataUri } />
         </Icon>
       </ToggleButton>
-    </Tooltip>
+    </label>
   )
 }
 

--- a/src/Main/AxesButton.jsx
+++ b/src/Main/AxesButton.jsx
@@ -15,7 +15,7 @@ function AxesButton(props) {
   }, [])
 
   return(
-    <Tooltip ref={ axesButton } title='Axes'>
+    <label ref={ axesButton } data-tooltip-right data-tooltip='Axes'>
       <ToggleButton
         size='small'
         className='toggleButton'
@@ -27,7 +27,7 @@ function AxesButton(props) {
           <img src={ axesIconDataUri }/>
         </Icon>
       </ToggleButton>
-    </Tooltip>
+    </label>
   )
 }
 

--- a/src/Main/BackgroundColorButton.jsx
+++ b/src/Main/BackgroundColorButton.jsx
@@ -14,13 +14,13 @@ function BackgroundColorButton(props) {
   }, [])
 
   return(
-    <Tooltip ref={ bgColorButton } title='Toggle Background Color'>
+    <label ref={ bgColorButton } data-tooltip-right data-tooltip='Toggle Background Color'>
       <IconButton size='small' onClick={() => { send('TOGGLE_BACKGROUND_COLOR') }}>
         <Icon>
           <img src={ selectColorIconDataUri } />
         </Icon>
       </IconButton>
-    </Tooltip>
+    </label>
   )
 }
 

--- a/src/Main/FullscreenButton.jsx
+++ b/src/Main/FullscreenButton.jsx
@@ -15,7 +15,7 @@ function FullscreenButton(props) {
   }, [])
 
   return(
-    <Tooltip ref={ fullscreenButton } title='Fullscreen [f]'>
+    <label ref={ fullscreenButton } data-tooltip-left data-tooltip='Fullscreen [f]'>
       <ToggleButton
         size='small'
         className='toggleButton'
@@ -27,7 +27,7 @@ function FullscreenButton(props) {
           <img src={ fullscreenIconDataUri } />
         </Icon>
       </ToggleButton>
-    </Tooltip>
+    </label>
   )
 }
 

--- a/src/Main/PlaneSliders.jsx
+++ b/src/Main/PlaneSliders.jsx
@@ -46,7 +46,7 @@ function PlaneSliders(props) {
         return(
           state.context.main[`${plane}Slice`] &&
             (<div key={ plane.toUpperCase() } className={`planeSliders ${ sliderVisible(plane) }`}>
-              <Tooltip title={`${plane.toUpperCase()} Plane Visibility`}>
+              <label data-tooltip-left data-tooltip={`${plane.toUpperCase()} Plane Visibility`}>
                 <IconButton
                   size='small'
                   className={`sliderIcons ${viewMode !== 'Volume' ? 'hidden' : ''}`}
@@ -59,8 +59,8 @@ function PlaneSliders(props) {
                     }
                   </Icon>
                 </IconButton>
-              </Tooltip>
-              <Tooltip title={`${plane} Plane Toggle Scroll`}>
+              </label>
+              <label data-tooltip-left data-tooltip={`${plane} Plane Toggle Scroll`}>
                 <IconButton
                   size='small'
                   className='sliderIcons'
@@ -73,7 +73,7 @@ function PlaneSliders(props) {
                     }
                   </Icon>
                 </IconButton>
-              </Tooltip>
+              </label>
               <Chip
                 className='sliderIcons'
                 size='small'

--- a/src/Main/ResetCameraButton.jsx
+++ b/src/Main/ResetCameraButton.jsx
@@ -14,13 +14,13 @@ function ResetCamerButton(props) {
   }, [])
 
   return(
-    <Tooltip ref={ resetCameraButton } title='Reset camera [r]'>
+    <label ref={ resetCameraButton } data-tooltip-right data-tooltip='Reset camera [r]'>
       <IconButton size='small' onClick={() => { send('RESET_CAMERA') }}>
         <Icon>
           <img src={ resetCameraIconDataUri } />
         </Icon>
       </IconButton>
-    </Tooltip>
+    </label>
   )
 }
 

--- a/src/Main/RotateButton.jsx
+++ b/src/Main/RotateButton.jsx
@@ -15,7 +15,7 @@ function RotateButton(props) {
   }, [])
 
   return(
-    <Tooltip ref={ rotateButton } title='Spin in 3D [p]'>
+    <label ref={ rotateButton } data-tooltip-left data-tooltip='Spin in 3D [p]'>
       <ToggleButton
         size='small'
         className='toggleButton'
@@ -27,7 +27,7 @@ function RotateButton(props) {
           <img src={ rotateIconDataUri } />
         </Icon>
       </ToggleButton>
-    </Tooltip>
+    </label>
   )
 }
 

--- a/src/Main/ScreenshotButton.jsx
+++ b/src/Main/ScreenshotButton.jsx
@@ -13,11 +13,11 @@ function ScreenshotButton(props) {
   }, [])
 
   return(
-    <Tooltip ref={ screenshotButton } title='Screenshot'>
+    <label ref={ screenshotButton } data-tooltip-left data-tooltip="Screenshot">
       <IconButton size='small' onClick={() => { send('TAKE_SCREENSHOT') }}>
         <Icon><img src={ screenshotIconDataUri }/></Icon>
       </IconButton>
-    </Tooltip>
+    </label>
   );
 }
 

--- a/src/Main/ViewModeButtons.jsx
+++ b/src/Main/ViewModeButtons.jsx
@@ -26,7 +26,7 @@ function ViewModeButtons(props) {
 
   return(
     <div className='viewModeButtons'>
-      <Tooltip ref={ xPlaneButton } title='X plane [1]'>
+      <label ref={ xPlaneButton } data-tooltip-left data-tooltip='X plane [1]'>
         <ToggleButton
           className='toggleButton'
           value='xplane'
@@ -41,8 +41,8 @@ function ViewModeButtons(props) {
             />
           </Icon>
         </ToggleButton>
-      </Tooltip>
-      <Tooltip ref={ yPlaneButton } title='Y plane [2]'>
+      </label>
+      <label ref={ yPlaneButton } data-tooltip-left data-tooltip='Y plane [2]'>
         <ToggleButton
           className='toggleButton'
           value='yplane'
@@ -57,8 +57,8 @@ function ViewModeButtons(props) {
             />
           </Icon>
         </ToggleButton>
-      </Tooltip>
-      <Tooltip ref={ zPlaneButton } title='z plane [3]'>
+      </label>
+      <label ref={ zPlaneButton } data-tooltip-left data-tooltip='z plane [3]'>
         <ToggleButton
           className='toggleButton'
           value='zplane'
@@ -73,8 +73,8 @@ function ViewModeButtons(props) {
             />
           </Icon>
         </ToggleButton>
-      </Tooltip>
-      <Tooltip ref={ volumeButton } title='Volume [4]'>
+      </label>
+      <label ref={ volumeButton } data-tooltip-left data-tooltip='Volume [4]'>
         <ToggleButton
           className='toggleButton'
           value='volume'
@@ -89,7 +89,7 @@ function ViewModeButtons(props) {
             />
           </Icon>
         </ToggleButton>
-      </Tooltip>
+      </label>
     </div>
   )
 }

--- a/src/Main/ViewPlanesToggle.jsx
+++ b/src/Main/ViewPlanesToggle.jsx
@@ -48,7 +48,7 @@ function ViewPlanesToggle(props) {
   }
 
   return(
-    <Tooltip ref={ viewPlanesButton } title='View planes [s]'>
+    <label ref={ viewPlanesButton } data-tooltip-right data-tooltip='View planes [s]'>
       <ToggleButton
         size='small'
         className='toggleButton'
@@ -60,7 +60,7 @@ function ViewPlanesToggle(props) {
           <img src={ viewPlanesIconDataUri } />
         </Icon>
       </ToggleButton>
-    </Tooltip>
+    </label>
   )
 }
 

--- a/src/Panel.css
+++ b/src/Panel.css
@@ -13,12 +13,13 @@
 .drawer {
   width: 15%;
   flex-shrink: 0;
+  z-index: 10;
 }
 
 .MuiDrawer-paper {
   width: fit-content;
   position: fixed;
-  top: 65px !important;
+  top: 60px !important;
   background: none !important;
   border: none !important;
 }

--- a/src/Panel.css
+++ b/src/Panel.css
@@ -1,5 +1,5 @@
 .root {
-  display: 'flex';
+  display: flex;
 }
 
 .appBar{

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -1,48 +1,19 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import {
-  AppBar, Drawer, Icon, IconButton, Toolbar, Typography
-} from '@material-ui/core'
-import { toggleIconDataUri } from 'itk-viewer-icons'
-import toggleUICollapsed from './toggleUICollapsed'
+import { Drawer } from '@material-ui/core'
 import './Panel.css'
 
 function Panel(props) {
   const { children, service } = props
   const uiPanel = useRef(null)
-  const collapseUIButton = useRef(null)
-  const [ state, send ] = useActor(service)
+  const [ state ] = useActor(service)
 
   useEffect(() => {
     state.context.uiPanel = uiPanel.current
-    state.context.main.collapseUIButton = collapseUIButton.current
   }, [])
-
-  const handleToggle = () => {
-    send('TOGGLE_UI_COLLAPSED')
-    toggleUICollapsed(state.context)
-  }
 
   return (
     <div ref={ uiPanel } className='root'>
-      <AppBar className='appBar'>
-        <Toolbar>
-          <IconButton
-            size='small'
-            ref={ collapseUIButton }
-            color='inherit'
-            onClick={ handleToggle }
-            edge='start'
-          >
-            <Icon>
-              <img src={ toggleIconDataUri } alt='toggle'/>
-            </Icon>
-          </IconButton>
-          <Typography variant='h5' noWrap>
-            ITK Viewer
-          </Typography>
-        </Toolbar>
-      </AppBar>
       <Drawer
         className='drawer'
         variant='persistent'

--- a/src/Widgets/DistanceWidget.jsx
+++ b/src/Widgets/DistanceWidget.jsx
@@ -31,7 +31,7 @@ function DistanceWidget(props) {
       ref={ distanceRulerRow }
       className={`uiRow distanceEntry ${viewMode === 'Volume' ? 'hidden' : ''}`}
     >
-      <Tooltip ref={ distanceButtonLabel } title='Length'>
+      <label ref={ distanceButtonLabel } data-tooltip-left data-tooltip='Length'>
         <ToggleButton
           ref={ distanceButtonInput }
           size='small'
@@ -44,7 +44,7 @@ function DistanceWidget(props) {
             <img src={ lengthToolIconDataUri }/>
           </Icon>
         </ToggleButton>
-      </Tooltip>
+      </label>
       <span ref={ distanceLabel } className='distanceLabelCommon'>
         Length:
       </span>

--- a/src/createInterface.jsx
+++ b/src/createInterface.jsx
@@ -6,6 +6,7 @@ import MainInterface from './Main/MainInterface'
 import LayersInterface from './Layers/LayersInterface'
 import ImagesInterface from './Images/ImagesInterface'
 import WidgetsInterface from './Widgets/WidgetsInterface'
+import AppToolbar from './AppToolbar'
 
 function createInterface(context) {
   context.viewContainers = new Map()
@@ -29,6 +30,7 @@ function createInterface(context) {
 
   ReactDOM.render(
     <React.StrictMode>
+      <AppToolbar service={ context.service }/>
       <Panel service={ context.service }>
         <MainInterface />
         <LayersInterface />

--- a/src/style.css
+++ b/src/style.css
@@ -4,6 +4,13 @@
   align-items: center;
 }
 
+.cmapMenu {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  width: 312px !important;
+}
+
 code.uiContainer {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
@@ -13,6 +20,46 @@ code.uiContainer {
   height: inherit;
   width: -webkit-fill-available;
   margin: 0 3px;
+}
+
+[data-tooltip] {
+  position: relative;
+}
+
+[data-tooltip]::after {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  content: attr(data-tooltip);
+  top: calc(100% + 10px);
+  z-index: 1;
+  max-width: 300px;
+  width: max-content;
+  transform: translateY(-20px);
+  transition: all 150ms cubic-bezier(.25, .8, .25, 1);
+  transition-delay: 0.8s;
+  text-align: center;
+  font-size: 0.8em;
+  border-radius: 3px;
+  background: rgba(0.9, 0.9, 0.9, 0.5);
+  color: white;
+  opacity: 0;
+  padding: 4px 6px;
+}
+
+[data-tooltip]:hover::after {
+  opacity: 1;
+  transform: translateY(0);
+  transition-duration: 300ms;
+  z-index: 10000;
+}
+
+[data-tooltip-left]::after {
+  left: 0;
+}
+
+[data-tooltip-right]::after {
+  right: 0;
 }
 
 .distanceEntry {
@@ -174,13 +221,6 @@ code.uiContainer {
 .MuiListItem-button {
   width: 100px !important;
   padding: 6px 0 !important;
-}
-
-.cmapMenu {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  width: 312px !important;
 }
 
 .MuiSelect-selectMenu {

--- a/src/vtk/ItkPiecewiseGaussianWidget.jsx
+++ b/src/vtk/ItkPiecewiseGaussianWidget.jsx
@@ -1,4 +1,4 @@
-import macro from '@kitware/vtk.js/macro'
+import macro from '@kitware/vtk.js/macros'
 import vtkPiecewiseGaussianWidget from '@kitware/vtk.js/Interaction/Widgets/PiecewiseGaussianWidget'
 
 /* eslint-disable no-continue */


### PR DESCRIPTION
Adds the following fixes:
- Use `macros` rather than `macro` to avoid bug with babel - see the related [issue](https://github.com/Kitware/vtk-js/issues/1990) and [PR](https://github.com/Kitware/vtk-js/pull/2001)
- Avoid a bug with Material-UI Tooltip that causes resizing of iframe and therefore makes the UI resize rapidly for no reason, rendering it useless. (Discussion [here](https://github.com/mui-org/material-ui/issues/23266)). Use native HTML to create tooltips instead.
- Break the toolbar out as its own component so that the user has the option to add just the toggle UI icon (useful for the Tensorboard plugin) or the entire Material-UI Toolbar (useful when creating a web application to give a feel more consistent with other Material-UI designs).
EX:
![collapse_icon](https://user-images.githubusercontent.com/51238406/142071104-b525276a-0651-43bd-be23-09205b10fa74.png)
![toolbar](https://user-images.githubusercontent.com/51238406/142071106-5d3fecab-c534-40c4-aea1-4ee0e29cb74f.png)
