### PR TITLE
Popper fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@emotion/react": "^11.6.0",
     "@emotion/styled": "^11.6.0",
     "@kitware/vtk.js": "^19.0.2",
+    "@mui/icons-material": "^5.1.1",
     "@mui/material": "^5.1.1",
     "@xstate/react": "^1.6.1",
     "itk-viewer-icons": "^11.11.2",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "itk-viewer"
   ],
   "dependencies": {
+    "@emotion/react": "^11.6.0",
+    "@emotion/styled": "^11.6.0",
     "@kitware/vtk.js": "^19.0.2",
-    "@material-ui/core": "^4.12.3",
-    "@material-ui/lab": "^4.0.0-alpha.60",
+    "@mui/material": "^5.1.1",
     "@xstate/react": "^1.6.1",
     "itk-viewer-icons": "^11.11.2",
     "react": "^17.0.0",

--- a/src/AppToolbar.jsx
+++ b/src/AppToolbar.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
 import {
   AppBar, Icon, IconButton, Toolbar, Typography
-} from '@material-ui/core'
+} from '@mui/material'
 import { toggleIconDataUri } from 'itk-viewer-icons'
 import toggleUICollapsed from './toggleUICollapsed'
 import './Panel.css'

--- a/src/CollapseUIButton.jsx
+++ b/src/CollapseUIButton.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, IconButton } from '@material-ui/core'
+import { Icon, IconButton } from '@mui/material'
 import { toggleIconDataUri } from 'itk-viewer-icons'
 import toggleUICollapsed from './toggleUICollapsed'
 import './Panel.css'

--- a/src/Images/BlendModeSelector.jsx
+++ b/src/Images/BlendModeSelector.jsx
@@ -9,12 +9,13 @@ function BlendModeSelector(props) {
   const { service } = props
   const blendModeDiv = useRef(null)
   const blendModeSelector = useRef(null)
+  const blendModeIcon = useRef(null)
   const [ state, send ] = useActor(service)
 
   useEffect(() => {
     applyContrastSensitiveStyleToElement(
-        state.context, 'invertibleButton', blendModeDiv.current)
-    state.context.images.blendModeDiv = blendModeDiv.current
+        state.context, 'invertibleButton', blendModeIcon.current)
+    state.context.images.blendModeDiv = blendModeIcon.current
     state.context.images.blendModeSelector = blendModeSelector.current
   }, [])
 
@@ -46,17 +47,31 @@ function BlendModeSelector(props) {
   }
 
   return(
-    <div className='blendSelector'>
-      <label ref={ blendModeDiv } data-tooltip-left data-tooltip='Blend mode'>
+    <div ref={ blendModeDiv } className='blendSelector'>
+      <Tooltip
+        ref={ blendModeIcon }
+        title='Blend mode'
+        PopperProps={{
+          anchorEl: blendModeIcon.current,
+          disablePortal: true,
+          keepMounted: true,
+        }}
+      >
         <Icon className='blendModeButton'>
           <img src={ blendModeIconDataUri }/>
         </Icon>
-      </label>
+      </Tooltip>
       <Select
         ref={ blendModeSelector }
         className='selector'
         defaultValue={ 0 }
         onChange={(event) => { selectionChanged(event) }}
+        MenuProps={{
+          anchorEl: blendModeSelector.current,
+          disablePortal: true,
+          keepMounted: true,
+          classes: { paper: 'blendMenu' }
+        }}
       >
         <MenuItem value={ 0 }>Composite</MenuItem>
         <MenuItem value={ 1 }>Maximum</MenuItem>

--- a/src/Images/BlendModeSelector.jsx
+++ b/src/Images/BlendModeSelector.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, MenuItem, Select, Tooltip } from '@material-ui/core'
+import { Icon, MenuItem, Select, Tooltip } from '@mui/material'
 import { blendModeIconDataUri } from 'itk-viewer-icons'
 import applyContrastSensitiveStyleToElement from '../applyContrastSensitiveStyleToElement'
 import '../style.css'

--- a/src/Images/ColorMapIconSelector.jsx
+++ b/src/Images/ColorMapIconSelector.jsx
@@ -54,7 +54,12 @@ function ColorMapIconSelector(props) {
         value={ currentColorMap() }
         style={{ height: '40px' }}
         onChange={(e) => { handleChange(e.target.value) }}
-        MenuProps={{ classes: { list: 'cmapMenu' } }}
+        MenuProps={{
+          anchorEl: iconSelector.current,
+          disablePortal: true,
+          keepMounted: true,
+          classes: { list: 'cmapMenu' }
+        }}
       >
         {colorMapIcons.map((preset, idx) => (
           <MenuItem key={idx} value={preset.name}>

--- a/src/Images/ColorMapIconSelector.jsx
+++ b/src/Images/ColorMapIconSelector.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { FormControl, Icon, MenuItem, Select } from '@material-ui/core'
+import { FormControl, Icon, MenuItem, Select } from '@mui/material'
 import ColorMapPresetIcons from '../ColorMapPresetIcons'
 import '../style.css'
 

--- a/src/Images/ColorRangeInput.jsx
+++ b/src/Images/ColorRangeInput.jsx
@@ -109,7 +109,7 @@ function ColorRangeInput(props) {
           variant='outlined'
           size='small'
           defaultValue={ currentRangeMin() }
-          onBlur={(e) => { rangeMinChanged(e.target.value) }}
+          onChange={(e) => { rangeMinChanged(e.target.value) }}
         />
         <ColorMapIconSelector { ...props }/>
         <TextField
@@ -119,7 +119,7 @@ function ColorRangeInput(props) {
           variant='outlined'
           size='small'
           defaultValue={ currentRangeMax() }
-          onBlur={(e) => { rangeMaxChanged(e.target.value) }}
+          onChange={(e) => { rangeMaxChanged(e.target.value) }}
         />
       </div>)
     : <div />

--- a/src/Images/ColorRangeInput.jsx
+++ b/src/Images/ColorRangeInput.jsx
@@ -8,6 +8,7 @@ import '../style.css'
 function ColorRangeInput(props) {
   const { service } = props
   const colorRangeInput = useRef(null)
+  const interpolationButton = useRef(null)
   const [ state, send ] = useActor(service)
   const name = state.context.images.selectedName
   const actorContext = state.context.images.actorContext.get(name)
@@ -80,7 +81,15 @@ function ColorRangeInput(props) {
         className='uiRow'
         style={{background: 'rgba(127, 127, 127, 0.5)'}}
       >
-        <label data-tooltip-left data-tooltip='Interpolation'>
+        <Tooltip
+          ref={ interpolationButton }
+          title='Interpolation'
+          PopperProps={{
+            anchorEl: interpolationButton.current,
+            disablePortal: true,
+            keepMounted: true,
+          }}
+        >
           <ToggleButton
 						size='small'
             className='interpolationButton toggleButton'
@@ -92,7 +101,7 @@ function ColorRangeInput(props) {
               <img src={ interpolationIconDataUri }/>
             </Icon>
           </ToggleButton>
-        </label>
+        </Tooltip>
         <TextField
           className='numberInput'
           type='number'

--- a/src/Images/ColorRangeInput.jsx
+++ b/src/Images/ColorRangeInput.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, TextField, Tooltip } from '@material-ui/core'
-import { ToggleButton } from '@material-ui/lab'
+import { Icon, TextField, ToggleButton, Tooltip } from '@mui/material'
 import { interpolationIconDataUri } from 'itk-viewer-icons'
 import ColorMapIconSelector from './ColorMapIconSelector'
 import '../style.css'

--- a/src/Images/GradientOpacitySlider.jsx
+++ b/src/Images/GradientOpacitySlider.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, IconButton, Slider, Tooltip } from '@material-ui/core'
+import { Icon, IconButton, Slider, Tooltip } from '@mui/material'
 import { gradientIconDataUri } from 'itk-viewer-icons'
 import applyContrastSensitiveStyleToElement from '../applyContrastSensitiveStyleToElement'
 import '../style.css'

--- a/src/Images/GradientOpacitySlider.jsx
+++ b/src/Images/GradientOpacitySlider.jsx
@@ -45,11 +45,19 @@ function GradientOpacitySlider(props) {
 
   return(
     <div className='iconWithSlider'>
-      <label ref={ sliderEntry } data-tooltip-left data-tooltip='Gradient opacity scale'>
+      <Tooltip
+        ref={ sliderEntry }
+        title='Gradient opacity scale'
+        PopperProps={{
+          anchorEl: sliderEntry.current,
+          disablePortal: true,
+          keepMounted: true,
+        }}
+      >
         <IconButton size='small' onClick={() => { setVertSlider(!vertSlider) }}>
           <Icon className='sliderEntry'><img src={ gradientIconDataUri }/></Icon>
         </IconButton>
-      </label>
+      </Tooltip>
       <div className='gradientOpacityScale'>
         <Slider
           ref={ gradientOpacitySlider }

--- a/src/Images/SampleDistanceSlider.jsx
+++ b/src/Images/SampleDistanceSlider.jsx
@@ -32,14 +32,22 @@ function SampleDistanceSlider(props) {
 
   return(
     <div className='iconWithSlider'>
-      <label ref={ spacingDiv } data-tooltip-top-screenshot='Volume sample distance'>
+      <Tooltip
+        ref={ spacingDiv }
+        title='Volume sample distance'
+        PopperProps={{
+          anchorEl: spacingDiv.current,
+          disablePortal: true,
+          keepMounted: true,
+        }}
+      >
         <Icon
           className='sampleDistanceButton'
-          style={{ margin: '0 10px 15px 0' }}
+          style={{ margin: '0 10px 0 0' }}
         >
           <img src={ sampleDistanceIconDataUri } />
         </Icon>
-      </label>
+      </Tooltip>
       <Slider
         ref={ spacingElement }
         className='slider'

--- a/src/Images/SampleDistanceSlider.jsx
+++ b/src/Images/SampleDistanceSlider.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, Slider, Tooltip } from '@material-ui/core'
+import { Icon, Slider, Tooltip } from '@mui/material'
 import { sampleDistanceIconDataUri } from 'itk-viewer-icons'
 import applyContrastSensitiveStyleToElement from '../applyContrastSensitiveStyleToElement'
 import '../style.css'

--- a/src/Images/ShadowToggle.jsx
+++ b/src/Images/ShadowToggle.jsx
@@ -19,7 +19,15 @@ function ShadowToggle(props) {
   }, [])
 
   return(
-    <label ref={ shadowButton } data-tooltip-left data-tooltip='Use Shadow'>
+    <Tooltip
+      ref={ shadowButton }
+      title='Use Shadow'
+      PopperProps={{
+        anchorEl: shadowButton.current,
+        disablePortal: true,
+        keepMounted: true,
+      }}
+    >
       <ToggleButton
 				size='small'
         className='toggleButton'
@@ -35,7 +43,7 @@ function ShadowToggle(props) {
           <img src={ shadowIconDataUri }/>
         </Icon>
       </ToggleButton>
-    </label>
+    </Tooltip>
   )
 }
 

--- a/src/Images/ShadowToggle.jsx
+++ b/src/Images/ShadowToggle.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, Tooltip } from '@material-ui/core'
-import { ToggleButton } from '@material-ui/lab'
+import { Icon, ToggleButton, Tooltip } from '@mui/material'
 import { shadowIconDataUri } from 'itk-viewer-icons'
 import applyContrastSensitiveStyleToElement from '../applyContrastSensitiveStyleToElement'
 import '../style.css'

--- a/src/Images/imagesUIMachineOptions.js
+++ b/src/Images/imagesUIMachineOptions.js
@@ -3,10 +3,14 @@ import applyColorMap from './applyColorMap'
 import applyPiecewiseFunctionGaussians from './applyPiecewiseFunctionGaussians'
 import applyHistogram from './applyHistogram'
 import ImagesInterface from './ImagesInterface'
+import updateImageInterface from './updateImageInterface'
+import updateRenderedImageInterface from './updateRenderedImageInterface'
 
 const imagesUIMachineOptions = {
   actions: {
     ImagesInterface,
+    updateImageInterface,
+    updateRenderedImageInterface,
 
     applyColorRange,
     applyColorMap,

--- a/src/Images/updateImageInterface.js
+++ b/src/Images/updateImageInterface.js
@@ -1,0 +1,36 @@
+import applyColorMap from './applyColorMap'
+import applyPiecewiseFunctionGaussians from './applyPiecewiseFunctionGaussians'
+
+
+function updateImageInterface(context) {
+  const name = context.images.selectedName
+  const actorContext = context.images.actorContext.get(name)
+  const image = actorContext.image
+  const component = actorContext.selectedComponent
+
+  if (image) {
+    if (actorContext.colorMaps.has(component)) {
+      const colorMap = actorContext.colorMaps.get(component)
+      applyColorMap(context, {
+        data: {
+          name,
+          component,
+          colorMap,
+        },
+      })
+    }
+
+    if (actorContext.piecewiseFunctionGaussians.has(component)) {
+      const gaussians = actorContext.piecewiseFunctionGaussians.get(component)
+      applyPiecewiseFunctionGaussians(context, {
+        data: {
+          name,
+          component,
+          gaussians,
+        },
+      })
+    }
+  }
+}
+
+export default updateImageInterface

--- a/src/Images/updateRenderedImageInterface.js
+++ b/src/Images/updateRenderedImageInterface.js
@@ -1,0 +1,42 @@
+function updateRenderedImageInterface(context, event) {
+    const name = event.data
+    const actorContext = context.images.actorContext.get(name)
+    const visualizedComponents = actorContext.visualizedComponents
+    const transferFunctionWidget = context.images.transferFunctionWidget
+  
+    // Apply piecewise functions
+    for (let i = 0; i < visualizedComponents.length; i++) {
+      const component = visualizedComponents[i]
+      if (component < 0) {
+        continue
+      }
+      context.images.selectedComponent = component
+      const gaussians = actorContext.piecewiseFunctionGaussians.get(component)
+      if (transferFunctionWidget && gaussians) {
+        transferFunctionWidget.setGaussians(gaussians)
+        const dataRange = actorContext.colorRanges.get(component)
+        const range = transferFunctionWidget.getOpacityRange(dataRange)
+        const nodes = transferFunctionWidget.getOpacityNodes(dataRange)
+        context.service.send({
+          type: 'IMAGE_PIECEWISE_FUNCTION_CHANGED',
+          data: {
+            name,
+            component,
+            range,
+            nodes,
+          },
+        })
+      }
+    }
+  
+    const selectedComponent = context.images.selectedComponent
+    const gaussians = actorContext.piecewiseFunctionGaussians.get(
+      selectedComponent
+    )
+    if (transferFunctionWidget && gaussians) {
+      transferFunctionWidget.setGaussians(gaussians)
+    }
+  }
+  
+  export default updateRenderedImageInterface
+  

--- a/src/Layers/LayerEntry.jsx
+++ b/src/Layers/LayerEntry.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, IconButton } from '@material-ui/core'
+import { Icon, IconButton } from '@mui/material'
 import {
   visibleIconDataUri,
   invisibleIconDataUri,

--- a/src/Layers/LayerInterface.jsx
+++ b/src/Layers/LayerInterface.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useActor } from '@xstate/react'
 import LayerEntry from './LayerEntry'
-import { Paper } from '@material-ui/core'
+import { Paper } from '@mui/material'
 
 function LayerInterface(props) {
   const { children, service } = props

--- a/src/Main/AnnotationsButton.jsx
+++ b/src/Main/AnnotationsButton.jsx
@@ -14,7 +14,15 @@ function AnnotationsButton(props) {
   }, [])
 
   return(
-    <label ref={ annotationsButton } data-tooltip-left data-tooltip='Annotations'>
+    <Tooltip
+      ref={ annotationsButton }
+      title='Annotations'
+      PopperProps={{
+        anchorEl: annotationsButton.current,
+        disablePortal: true,
+        keepMounted: true,
+      }}
+    >
       <ToggleButton
         size='small'
         className='toggleButton'
@@ -26,7 +34,7 @@ function AnnotationsButton(props) {
           <img src={ annotationsIconDataUri } />
         </Icon>
       </ToggleButton>
-    </label>
+    </Tooltip>
   )
 }
 

--- a/src/Main/AnnotationsButton.jsx
+++ b/src/Main/AnnotationsButton.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, Tooltip } from '@material-ui/core'
-import { ToggleButton } from '@material-ui/lab'
+import { Icon, ToggleButton, Tooltip } from '@mui/material'
 import { annotationsIconDataUri } from 'itk-viewer-icons'
 import '../style.css'
 

--- a/src/Main/AxesButton.jsx
+++ b/src/Main/AxesButton.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, Tooltip } from '@material-ui/core'
-import { ToggleButton } from '@material-ui/lab'
+import { Icon, ToggleButton, Tooltip } from '@mui/material'
 import { axesIconDataUri } from 'itk-viewer-icons'
 import '../style.css'
 

--- a/src/Main/AxesButton.jsx
+++ b/src/Main/AxesButton.jsx
@@ -14,7 +14,15 @@ function AxesButton(props) {
   }, [])
 
   return(
-    <label ref={ axesButton } data-tooltip-right data-tooltip='Axes'>
+    <Tooltip
+      ref={ axesButton }
+      title='Axes'
+      PopperProps={{
+        anchorEl: axesButton.current,
+        disablePortal: true,
+        keepMounted: true,
+      }}
+    >
       <ToggleButton
         size='small'
         className='toggleButton'
@@ -26,7 +34,7 @@ function AxesButton(props) {
           <img src={ axesIconDataUri }/>
         </Icon>
       </ToggleButton>
-    </label>
+    </Tooltip>
   )
 }
 

--- a/src/Main/BackgroundColorButton.jsx
+++ b/src/Main/BackgroundColorButton.jsx
@@ -14,13 +14,21 @@ function BackgroundColorButton(props) {
   }, [])
 
   return(
-    <label ref={ bgColorButton } data-tooltip-right data-tooltip='Toggle Background Color'>
+    <Tooltip
+      ref={ bgColorButton }
+      title='Toggle Background Color'
+      PopperProps={{
+        anchorEl: bgColorButton.current,
+        disablePortal: true,
+        keepMounted: true,
+      }}
+    >
       <IconButton size='small' onClick={() => { send('TOGGLE_BACKGROUND_COLOR') }}>
         <Icon>
           <img src={ selectColorIconDataUri } />
         </Icon>
       </IconButton>
-    </label>
+    </Tooltip>
   )
 }
 

--- a/src/Main/BackgroundColorButton.jsx
+++ b/src/Main/BackgroundColorButton.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, IconButton, Tooltip } from '@material-ui/core'
+import { Icon, IconButton, Tooltip } from '@mui/material'
 import { selectColorIconDataUri } from 'itk-viewer-icons'
 import '../style.css'
 

--- a/src/Main/FullscreenButton.jsx
+++ b/src/Main/FullscreenButton.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, Tooltip } from '@material-ui/core'
-import { ToggleButton } from '@material-ui/lab'
+import { Icon, ToggleButton, Tooltip } from '@mui/material'
 import { fullscreenIconDataUri } from 'itk-viewer-icons'
 import '../style.css'
 

--- a/src/Main/FullscreenButton.jsx
+++ b/src/Main/FullscreenButton.jsx
@@ -14,7 +14,15 @@ function FullscreenButton(props) {
   }, [])
 
   return(
-    <label ref={ fullscreenButton } data-tooltip-left data-tooltip='Fullscreen [f]'>
+    <Tooltip
+      ref={ fullscreenButton }
+      title='Fullscreen [f]'
+      PopperProps={{
+        anchorEl: fullscreenButton.current,
+        disablePortal: true,
+        keepMounted: true,
+      }}
+    >
       <ToggleButton
         size='small'
         className='toggleButton'
@@ -26,7 +34,7 @@ function FullscreenButton(props) {
           <img src={ fullscreenIconDataUri } />
         </Icon>
       </ToggleButton>
-    </label>
+    </Tooltip>
   )
 }
 

--- a/src/Main/PlaneSliders.jsx
+++ b/src/Main/PlaneSliders.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { useActor } from '@xstate/react'
 import { Chip, Icon, IconButton, Slider, Tooltip } from '@mui/material'
 import { visibleIconDataUri, invisibleIconDataUri, pauseIconDataUri, playIconDataUri } from 'itk-viewer-icons'
@@ -7,7 +7,15 @@ import '../style.css'
 function PlaneSliders(props) {
   const { service } = props
   const [ state, send ] = useActor(service)
+  const xVisibility = useRef(null)
+  const yVisibility = useRef(null)
+  const zVisibility = useRef(null)
+  const xScroll = useRef(null)
+  const yScroll = useRef(null)
+  const zScroll = useRef(null)
   const planes = ['x', 'y', 'z']
+  const visRefs = [xVisibility, yVisibility, zVisibility]
+  const scrollRefs = [xScroll, yScroll, zScroll]
   const { slicingPlanes, viewMode } = state.context.main
 
   const toggleVisibility = (plane) => {
@@ -42,11 +50,19 @@ function PlaneSliders(props) {
 
   return(
     <div className={`${state.context.uiCollapsed ? 'hidden' : 'uiSlidersGroup'}`}>
-      {planes.map((plane) => {
+      {planes.map((plane, idx) => {
         return(
           state.context.main[`${plane}Slice`] &&
             (<div key={ plane.toUpperCase() } className={`planeSliders ${ sliderVisible(plane) }`}>
-              <label data-tooltip-left data-tooltip={`${plane.toUpperCase()} Plane Visibility`}>
+              <Tooltip
+                ref={visRefs[idx]}
+                title={`${plane.toUpperCase()} Plane Visibility`}
+                PopperProps={{
+                  anchorEl: visRefs[idx].current,
+                  disablePortal: true,
+                  keepMounted: true,
+                }}
+              >
                 <IconButton
                   size='small'
                   className={`sliderIcons ${viewMode !== 'Volume' ? 'hidden' : ''}`}
@@ -59,8 +75,16 @@ function PlaneSliders(props) {
                     }
                   </Icon>
                 </IconButton>
-              </label>
-              <label data-tooltip-left data-tooltip={`${plane} Plane Toggle Scroll`}>
+              </Tooltip>
+              <Tooltip
+                ref={scrollRefs[idx]}
+                title={`${plane.toUpperCase()} Plane Toggle Scroll`}
+                PopperProps={{
+                  anchorEl: scrollRefs[idx].current,
+                  disablePortal: true,
+                  keepMounted: true,
+                }}
+              >
                 <IconButton
                   size='small'
                   className='sliderIcons'
@@ -73,7 +97,7 @@ function PlaneSliders(props) {
                     }
                   </Icon>
                 </IconButton>
-              </label>
+              </Tooltip>
               <Chip
                 className='sliderIcons'
                 size='small'

--- a/src/Main/PlaneSliders.jsx
+++ b/src/Main/PlaneSliders.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useActor } from '@xstate/react'
-import { Chip, Icon, IconButton, Slider, Tooltip } from '@material-ui/core'
+import { Chip, Icon, IconButton, Slider, Tooltip } from '@mui/material'
 import { visibleIconDataUri, invisibleIconDataUri, pauseIconDataUri, playIconDataUri } from 'itk-viewer-icons'
 import '../style.css'
 

--- a/src/Main/ResetCameraButton.jsx
+++ b/src/Main/ResetCameraButton.jsx
@@ -14,13 +14,21 @@ function ResetCamerButton(props) {
   }, [])
 
   return(
-    <label ref={ resetCameraButton } data-tooltip-right data-tooltip='Reset camera [r]'>
+    <Tooltip
+      ref={ resetCameraButton }
+      title='Reset camera [r]'
+      PopperProps={{
+        anchorEl: resetCameraButton.current,
+        disablePortal: true,
+        keepMounted: true,
+      }}
+    >
       <IconButton size='small' onClick={() => { send('RESET_CAMERA') }}>
         <Icon>
           <img src={ resetCameraIconDataUri } />
         </Icon>
       </IconButton>
-    </label>
+    </Tooltip>
   )
 }
 

--- a/src/Main/ResetCameraButton.jsx
+++ b/src/Main/ResetCameraButton.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, IconButton, Tooltip } from '@material-ui/core'
+import { Icon, IconButton, Tooltip } from '@mui/material'
 import { resetCameraIconDataUri } from 'itk-viewer-icons'
 import '../style.css'
 

--- a/src/Main/RotateButton.jsx
+++ b/src/Main/RotateButton.jsx
@@ -14,7 +14,15 @@ function RotateButton(props) {
   }, [])
 
   return(
-    <label ref={ rotateButton } data-tooltip-left data-tooltip='Spin in 3D [p]'>
+    <Tooltip
+      ref={ rotateButton }
+      title='Spin in 3D [p]'
+      PopperProps={{
+        anchorEl: rotateButton.current,
+        disablePortal: true,
+        keepMounted: true,
+      }}
+    >
       <ToggleButton
         size='small'
         className='toggleButton'
@@ -26,7 +34,7 @@ function RotateButton(props) {
           <img src={ rotateIconDataUri } />
         </Icon>
       </ToggleButton>
-    </label>
+    </Tooltip>
   )
 }
 

--- a/src/Main/RotateButton.jsx
+++ b/src/Main/RotateButton.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, Tooltip } from '@material-ui/core'
-import { ToggleButton } from '@material-ui/lab'
+import { Icon, ToggleButton, Tooltip } from '@mui/material'
 import { rotateIconDataUri } from 'itk-viewer-icons'
 import '../style.css'
 

--- a/src/Main/ScreenshotButton.jsx
+++ b/src/Main/ScreenshotButton.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { useActor } from '@xstate/react';
-import { Icon, IconButton, Tooltip } from "@material-ui/core";
+import { Icon, IconButton, Tooltip } from "@mui/material";
 import { screenshotIconDataUri } from 'itk-viewer-icons'
 
 function ScreenshotButton(props) {

--- a/src/Main/ScreenshotButton.jsx
+++ b/src/Main/ScreenshotButton.jsx
@@ -13,11 +13,19 @@ function ScreenshotButton(props) {
   }, [])
 
   return(
-    <label ref={ screenshotButton } data-tooltip-left data-tooltip="Screenshot">
+    <Tooltip
+      ref={ screenshotButton }
+      title="Screenshot"
+      PopperProps={{
+        anchorEl: screenshotButton.current,
+        disablePortal: true,
+        keepMounted: true,
+      }}
+    >
       <IconButton size='small' onClick={() => { send('TAKE_SCREENSHOT') }}>
         <Icon><img src={ screenshotIconDataUri }/></Icon>
       </IconButton>
-    </label>
+    </Tooltip>
   );
 }
 

--- a/src/Main/ViewModeButtons.jsx
+++ b/src/Main/ViewModeButtons.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, Tooltip } from '@material-ui/core'
-import { ToggleButton } from '@material-ui/lab'
+import { Icon, ToggleButton, Tooltip } from '@mui/material'
 import {
   volumeIconDataUri,
   redPlaneIconDataUri,

--- a/src/Main/ViewModeButtons.jsx
+++ b/src/Main/ViewModeButtons.jsx
@@ -25,8 +25,17 @@ function ViewModeButtons(props) {
 
   return(
     <div className='viewModeButtons'>
-      <label ref={ xPlaneButton } data-tooltip-left data-tooltip='X plane [1]'>
+      <Tooltip
+        ref={ xPlaneButton }
+        title='X plane [1]'
+        PopperProps={{
+          anchorEl: xPlaneButton.current,
+          disablePortal: true,
+          keepMounted: true,
+        }}
+      >
         <ToggleButton
+          size='small'
           className='toggleButton'
           value='xplane'
           selected={ state.context.main.xPlaneButton }
@@ -40,9 +49,18 @@ function ViewModeButtons(props) {
             />
           </Icon>
         </ToggleButton>
-      </label>
-      <label ref={ yPlaneButton } data-tooltip-left data-tooltip='Y plane [2]'>
+      </Tooltip>
+      <Tooltip
+        ref={ yPlaneButton }
+        title='Y plane [2]'
+        PopperProps={{
+          anchorEl: yPlaneButton.current,
+          disablePortal: true,
+          keepMounted: true,
+        }}
+      >
         <ToggleButton
+          size='small'
           className='toggleButton'
           value='yplane'
           selected={ state.context.main.yPlaneButton }
@@ -56,9 +74,18 @@ function ViewModeButtons(props) {
             />
           </Icon>
         </ToggleButton>
-      </label>
-      <label ref={ zPlaneButton } data-tooltip-left data-tooltip='z plane [3]'>
+      </Tooltip>
+      <Tooltip
+        ref={ zPlaneButton }
+        title='z plane [3]'
+        PopperProps={{
+          anchorEl: zPlaneButton.current,
+          disablePortal: true,
+          keepMounted: true,
+        }}
+      >
         <ToggleButton
+          size='small'
           className='toggleButton'
           value='zplane'
           selected={ state.context.main.zPlaneButton }
@@ -72,9 +99,18 @@ function ViewModeButtons(props) {
             />
           </Icon>
         </ToggleButton>
-      </label>
-      <label ref={ volumeButton } data-tooltip-left data-tooltip='Volume [4]'>
+      </Tooltip>
+      <Tooltip
+        ref={ volumeButton }
+        title='Volume [4]'
+        PopperProps={{
+          anchorEl: volumeButton.current,
+          disablePortal: true,
+          keepMounted: true,
+        }}
+      >
         <ToggleButton
+          size='small'
           className='toggleButton'
           value='volume'
           selected={ state.context.main.volumeButton }
@@ -88,7 +124,7 @@ function ViewModeButtons(props) {
             />
           </Icon>
         </ToggleButton>
-      </label>
+      </Tooltip>
     </div>
   )
 }

--- a/src/Main/ViewPlanesToggle.jsx
+++ b/src/Main/ViewPlanesToggle.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, Tooltip } from '@material-ui/core'
-import { ToggleButton } from '@material-ui/lab'
+import { Icon, ToggleButton, Tooltip } from '@mui/material'
 import { viewPlanesIconDataUri } from 'itk-viewer-icons'
 
 function ViewPlanesToggle(props) {

--- a/src/Main/ViewPlanesToggle.jsx
+++ b/src/Main/ViewPlanesToggle.jsx
@@ -47,7 +47,15 @@ function ViewPlanesToggle(props) {
   }
 
   return(
-    <label ref={ viewPlanesButton } data-tooltip-right data-tooltip='View planes [s]'>
+    <Tooltip
+      ref={ viewPlanesButton }
+      title='View planes [s]'
+      PopperProps={{
+        anchorEl: viewPlanesButton.current,
+        disablePortal: true,
+        keepMounted: true,
+      }}
+    >
       <ToggleButton
         size='small'
         className='toggleButton'
@@ -59,7 +67,7 @@ function ViewPlanesToggle(props) {
           <img src={ viewPlanesIconDataUri } />
         </Icon>
       </ToggleButton>
-    </label>
+    </Tooltip>
   )
 }
 

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Drawer } from '@material-ui/core'
+import { Drawer } from '@mui/material'
 import './Panel.css'
 
 function Panel(props) {

--- a/src/Widgets/DistanceWidget.jsx
+++ b/src/Widgets/DistanceWidget.jsx
@@ -30,7 +30,15 @@ function DistanceWidget(props) {
       ref={ distanceRulerRow }
       className={`uiRow distanceEntry ${viewMode === 'Volume' ? 'hidden' : ''}`}
     >
-      <label ref={ distanceButtonLabel } data-tooltip-left data-tooltip='Length'>
+      <Tooltip
+        ref={ distanceButtonLabel }
+        title='Length'
+        PopperProps={{
+          anchorEl: distanceButtonLabel.current,
+          disablePortal: true,
+          keepMounted: true,
+        }}
+      >
         <ToggleButton
           ref={ distanceButtonInput }
           size='small'
@@ -43,7 +51,7 @@ function DistanceWidget(props) {
             <img src={ lengthToolIconDataUri }/>
           </Icon>
         </ToggleButton>
-      </label>
+      </Tooltip>
       <span ref={ distanceLabel } className='distanceLabelCommon'>
         Length:
       </span>

--- a/src/Widgets/DistanceWidget.jsx
+++ b/src/Widgets/DistanceWidget.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, TextField, Tooltip } from '@material-ui/core'
-import { ToggleButton } from '@material-ui/lab'
+import { Icon, TextField, ToggleButton, Tooltip } from '@mui/material'
 import { lengthToolIconDataUri } from 'itk-viewer-icons'
 import applyContrastSensitiveStyleToElement from '../applyContrastSensitiveStyleToElement'
 import '../style.css'

--- a/src/style.css
+++ b/src/style.css
@@ -1,7 +1,15 @@
+.blendMenu {
+  min-width: auto !important;
+}
+
+.blendModeButton {
+  margin-right: 5px;
+}
+
 .blendSelector {
   display: flex;
-  margin-bottom: 12px;
   align-items: center;
+  margin-left: 10px;
 }
 
 .cmapMenu {
@@ -20,46 +28,6 @@ code.uiContainer {
   height: inherit;
   width: -webkit-fill-available;
   margin: 0 3px;
-}
-
-[data-tooltip] {
-  position: relative;
-}
-
-[data-tooltip]::after {
-  position: absolute;
-  opacity: 0;
-  pointer-events: none;
-  content: attr(data-tooltip);
-  top: calc(100% + 10px);
-  z-index: 1;
-  max-width: 300px;
-  width: max-content;
-  transform: translateY(-20px);
-  transition: all 150ms cubic-bezier(.25, .8, .25, 1);
-  transition-delay: 0.8s;
-  text-align: center;
-  font-size: 0.8em;
-  border-radius: 3px;
-  background: rgba(0.9, 0.9, 0.9, 0.5);
-  color: white;
-  opacity: 0;
-  padding: 4px 6px;
-}
-
-[data-tooltip]:hover::after {
-  opacity: 1;
-  transform: translateY(0);
-  transition-duration: 300ms;
-  z-index: 10000;
-}
-
-[data-tooltip-left]::after {
-  left: 0;
-}
-
-[data-tooltip-right]::after {
-  right: 0;
 }
 
 .distanceEntry {
@@ -218,9 +186,13 @@ code.uiContainer {
   height: inherit;
 }
 
-.MuiListItem-button {
+.MuiMenuItem-root {
   width: 100px !important;
   padding: 6px 0 !important;
+}
+
+.MuiSelect-select {
+  padding: 10px 30px 10px 10px !important;
 }
 
 .MuiSelect-selectMenu {
@@ -269,7 +241,7 @@ code.uiContainer {
   flex: 1;
   min-height: 1rem;
   width: 5px;
-  align-self: flex-end;
+  align-self: center;
 }
 
 .sliderEntry {

--- a/src/style.css
+++ b/src/style.css
@@ -26,7 +26,7 @@ code.uiContainer {
 
 .colorMapIcon {
   height: inherit;
-  width: -webkit-fill-available;
+  width: 100%;
   margin: 0 3px;
 }
 
@@ -72,7 +72,7 @@ code.uiContainer {
 }
 
 .iconWithSlider {
-  width: -webkit-fill-available;
+  width: 100%;
   display: flex;
   align-self: normal;
   align-items: center;
@@ -94,7 +94,6 @@ code.uiContainer {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: -webkit-fill-available;
   border-width: 2px !important;
   border-color: rgba(255, 255, 255, 0.3) !important;
   border: solid;


### PR DESCRIPTION
- Fixes issues seen with the Material-UI Tooltip component so that it does not cause resizing when the app is rendered in an iframe
- Bump the Material-UI to v5
- Fix some css styling to be compatible with Firefox browser
- Add a missing update function to ensure volume is rendered on initial app load