### PR TITLE
fix(tooltip position): Set colormap tooltips to bottom position

### DIFF
--- a/src/Images/ColorMapIconSelector.jsx
+++ b/src/Images/ColorMapIconSelector.jsx
@@ -69,6 +69,7 @@ function ColorMapIconSelector(props) {
             <Tooltip
               ref={preset.ref}
               title={preset.name}
+              placement="bottom"
               PopperProps={{
                 anchorEl: preset.ref.current,
                 disablePortal: true,


### PR DESCRIPTION
This change prevents jumpy behavior caused by automatic tooltip positioning. In other positions the menu resizes rapidly to try and accommodate the tooltip.