### PR TITLE
fix(range): Make sure that color range is updated on state change

### DIFF
--- a/src/Images/ColorRangeInput.jsx
+++ b/src/Images/ColorRangeInput.jsx
@@ -52,12 +52,17 @@ function ColorRangeInput(props) {
   }
 
   const rangeChanged = (minVal, maxVal) => {
+    const bounds = actorContext.colorRangeBounds.get(
+      actorContext.selectedComponent
+    )
+    const rangeMin = minVal < bounds[0] ? bounds[0] : minVal
+    const rangeMax = maxVal > bounds[1] ? bounds[1] : maxVal
     send({
       type: 'IMAGE_COLOR_RANGE_CHANGED',
       data: {
         name,
         component: actorContext.selectedComponent,
-        range: [minVal, maxVal]
+        range: [rangeMin, rangeMax]
       }
     })
   }
@@ -107,7 +112,7 @@ function ColorRangeInput(props) {
         label="Min"
         variant="outlined"
         size="small"
-        defaultValue={currentRangeMin()}
+        value={currentRangeMin()}
         onChange={(e) => {
           rangeMinChanged(e.target.value)
         }}
@@ -119,7 +124,7 @@ function ColorRangeInput(props) {
         label="Max"
         variant="outlined"
         size="small"
-        defaultValue={currentRangeMax()}
+        value={currentRangeMax()}
         onChange={(e) => {
           rangeMaxChanged(e.target.value)
         }}


### PR DESCRIPTION
The color range was previously only updated in the UI on user change. This was initially not an issue because that was the only way to change the range. With the changes introduced in KitwareMedical/tensorboard-plugin-3d#42 we need to make sure that the input fields reflect user changes as well as state changes not made by the user.