### PR TITLE
fix(ComponentSelector): Avoid crashing if user inputs labelImage

### DIFF
--- a/src/Images/ComponentSelector.jsx
+++ b/src/Images/ComponentSelector.jsx
@@ -11,7 +11,7 @@ function ComponentSelector(props) {
 
   const name = state.context.images.selectedName
   const actorContext = state.context.images.actorContext.get(name)
-  const components = actorContext.image.imageType.components
+  const components = actorContext.image?.imageType.components
 
   useEffect(() => {
     state.context.images.componentRow = componentRow.current


### PR DESCRIPTION
This avoids the error 
```
Uncaught TypeError: Cannot read properties of null (reading 'imageType')
```
if user input is just a `labelImage` without an `ipfsImage`,