### PR TITLE
feat(semantic-release): Add release branch in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/InsightSoftwareConsortium/itk-viewer-material-ui.git"
+  },
+"release": {
+  "branches": ["master", "next"]
   }
 }


### PR DESCRIPTION
Following recommendation in the [docs](https://semantic-release.gitbook.io/semantic-release/v/beta/usage/configuration).
This is an attempt to fix the error `ERELEASEBRANCHES The release branches are invalid in the `branches` configuration.` in commit c17ee2a69644a318bfe51bb6d97f8feae962c421.