### PR TITLE
fix(ColorMapIconSelector): Fix tooltip position

### DIFF
--- a/src/Images/ColorMapIconSelector.jsx
+++ b/src/Images/ColorMapIconSelector.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useActor } from '@xstate/react'
 import { FormControl, Icon, MenuItem, Select, Tooltip } from '@mui/material'
 import { ColorMapIcons } from 'itk-viewer-color-maps'
@@ -8,6 +8,7 @@ function ColorMapIconSelector(props) {
   const { service } = props
   const iconSelector = useRef(null)
   const [state, send] = useActor(service)
+  const [menuOpen, toggleMenuOpen] = useState(false)
   let colorMapIcons = []
   ColorMapIcons.forEach((value, key) => {
     colorMapIcons.push({
@@ -54,6 +55,8 @@ function ColorMapIconSelector(props) {
         onChange={(e) => {
           handleChange(e.target.value)
         }}
+        onOpen={() => {toggleMenuOpen(true)}}
+        onClose={() => {toggleMenuOpen(false)}}
         MenuProps={{
           anchorEl: iconSelector.current,
           disablePortal: true,
@@ -68,7 +71,7 @@ function ColorMapIconSelector(props) {
               title={preset.name}
               placement="bottom"
               PopperProps={{
-                anchorEl: preset.ref.current,
+                anchorEl: menuOpen ? preset.ref.current : iconSelector.current,
                 disablePortal: true,
                 keepMounted: true
               }}


### PR DESCRIPTION
Fixes incorrect positioning of the colormap tooltip when collapsed.

Before:
![tooltip_bug](https://user-images.githubusercontent.com/51238406/195356641-1d28f393-db0c-419d-8ef3-5247691f7a79.png)

Fixed:
![fixed_tooltip](https://user-images.githubusercontent.com/51238406/195356705-61ac4a8a-50c1-4f2b-a080-1ea1d99a4110.png)
